### PR TITLE
Provide install script for Linux and Mac

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  check:
-    name: check
+  check-linux-macos:
+    name: "check linux and macos"
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -61,9 +61,25 @@ jobs:
           command: run
           args: --release --features user-doc -- user-doc ./docs
 
+  check-installer:
+    name: "check installer"
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-latest, ubuntu-latest]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run installer
+        run: ./install.sh -v
+
+      - name: Run binary
+        run: rnk --version
+
   ci:
     runs-on: ubuntu-latest
-    needs: [check, check-win]
+    needs: [check-linux-macos, check-win, check-installer]
     steps:
       - name: Aggregate of lint, and all tests
         run: echo "ci passed"

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,14 @@
+(
+  import
+  (
+    let
+      lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+    in
+      fetchTarball {
+        url = lock.nodes.flake-compat.locked.url or "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
+        sha256 = lock.nodes.flake-compat.locked.narHash;
+      }
+  )
+  {src = ./.;}
+)
+.defaultNix

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,72 +4,9 @@ This is the documentation for the command line interface to the Renku
 platform.
 
 
-## Installation
+## Contents
 
-The binary name for the renku-cli is `rnk`.
-
-### Manual Download
-
-You can download the binary for your platform from the [release
-page](https://github.com/SwissDataScienceCenter/renku-cli/releases/latest).
-
-If you run on MacOS, download the `*-darwin` binary. If you run some
-form of linux, try `*-amd64` or `*-aarch64`. Last for Windows use the
-`*-windows` binary.
-
-Once downloaded, you can simply execute it without any further
-installation step.
-
-#### shell completion
-
-For convenience, the cli tool can generate completion commands for
-several shells. You can use it for inclusion in your `.bashrc` or
-similar setups.
-
-For example:
-
-``` bash rnk:silent
-rnk shell-completion --shell bash
-```
-
-will generate the completions for bash. These have to be "sourced"
-into into your current shell:
-
-``` bash
-eval "$(rnk shell-completion --shell bash)"
-```
-
-Add this line to your `.bashrc` to have these completions available
-when you enter bash.
-
-With this enabled, when you type `rnk <tab>` you will be presented
-with possible options, that are narrowed down the more letters you
-type.
-
-### Nix User
-
-If you are a nix user and have flakes enabled, you can install rnk
-from this repository:
-
-```
-nix profile install github:SwissDatascienceCenter/renku-cli
-```
-
-If you want to try it out without installing:
-```
-nix run github:SwissDatascienceCenter/renku-cli
-```
-
-When installing the package via `install` or including it into your
-NixOS configuration, the shell completions are already installed.
-
-### Debian/Ubuntu User
-
-TODO
-
-### Mac Homebrew
-
-TODO
+- [Installation](./install.md)
 
 ## Getting started
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,0 +1,144 @@
+# Install
+
+The binary name for the renku-cli is `rnk`.
+
+## Manual
+
+You can download the binary for your platform from the [release
+page](https://github.com/SwissDataScienceCenter/renku-cli/releases/latest).
+
+If you run on MacOS, download the `*-darwin` binary. If you run some
+form of linux, try `*-amd64` or `*-aarch64`. Last for Windows use the
+`*-windows` binary.
+
+Once downloaded, you can simply execute it without any further
+installation step.
+
+## Nix and NixOS
+
+### Nix
+
+If you are a [nix](https://nixos.org/nix) user and have flakes
+enabled, you can install rnk from this repository:
+
+```
+nix profile install github:SwissDatascienceCenter/renku-cli/<version>
+```
+
+If `/<version>` is omitted, it will install the current development
+version right off the `main` branch.
+
+If you want to try it out without installing:
+```
+nix run github:SwissDatascienceCenter/renku-cli
+```
+
+When installing the package via `install` or including it into your
+NixOS configuration, the shell completions are already installed.
+
+### NixOS
+
+When you are a NixOS user, you can include the flake and select the
+provided package in your `configuration.nix`. Here is an example:
+
+``` nix
+{
+  description = "Example rnk for NixOS";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.05";
+    rnk.url = "github:SwissDataScienceCenter/renku-cli/<version>";
+  };
+
+  outputs = inputs @ {
+    self,
+    nixpkgs,
+    rnk,
+    ...
+  }: let
+    system = "x86_64-linux";
+
+    overlays = [
+      # ... more of your overlays
+      rnk.overlays.default
+    ];
+
+    pkgsBySystem = system:
+      import nixpkgs {
+        inherit system;
+        inherit overlays;
+      };
+
+    modules = [
+      {
+        # build as a container to remove the need for specific
+        # filesystems
+        boot.isContainer = true;
+        system.stateVersion = "24.05";
+        # set pkgs to be the one with overlays applied
+        nixpkgs.pkgs = pkgsBySystem system;
+      }
+
+      # select rnk as a package in your modules
+      ({pkgs, ...}: {environment.systemPackages = [pkgs.rnk];})
+    ];
+  in {
+    nixosConfigurations.mymachine = nixpkgs.lib.nixosSystem {
+      inherit system modules;
+      specialArgs = inputs;
+    };
+  };
+}
+```
+
+The above configuration can be build into a NixOS system:
+``` bash
+nix build .#nixosConfigurations.mymachine.config.system.build.toplevel
+```
+
+If you are not using flakes, you can import the derivation from
+`default.nix`.
+
+You can omit `/<version>` in the input url, if you want to install
+latest development version, otherwise replace `<version>` with an
+existing tag.
+
+## Linux and Mac User
+
+The convenient way is to use the `installer.sh` script that is
+provided from this repository. It will download the correct binary
+from the release page and put it in `/usr/local/bin` on your system.
+It requires `curl` and `sudo` to copy the binary to `/usr/local/bin`.
+
+```
+curl -sfSL https://raw.githubusercontent.com/SwissDataScienceCenter/renku-cli/main/install.sh | bash
+```
+
+If you want to uninstall, simply remove the `/usr/local/bin/rnk` file.
+
+
+## Shell Completion
+
+For convenience, the cli tool can generate completion commands for
+several shells. You can use it for inclusion in your `.bashrc` or
+similar setups.
+
+For example:
+
+``` bash rnk:silent
+rnk shell-completion --shell bash
+```
+
+will generate the completions for bash. These have to be "sourced"
+into into your current shell:
+
+``` bash
+eval "$(rnk shell-completion --shell bash)"
+```
+
+Add this line to your `.bashrc` to have these completions available
+when you enter bash.
+
+With this enabled, when you type `rnk <tab>` you will be presented
+with possible options, that are narrowed down the more letters you
+type.

--- a/flake.nix
+++ b/flake.nix
@@ -190,5 +190,10 @@
           fenixToolChain.rustfmt
         ];
       };
-    });
+    })
+    // {
+      overlays.default = final: prev: {
+        rnk = self.packages.${prev.system}.default;
+      };
+    };
 }

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,207 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+os=$(uname)
+arch=$(uname -m)
+dist=$(uname -o)
+api_url_prefix="${API_URL_PREFIX:-https://api.github.com/repos/SwissDataScienceCenter/renku-cli/releases}"
+dl_url_prefix="${DL_URL_PREFIX:-https://github.com/SwissDataScienceCenter/renku-cli/releases}"
+binary_name="${BINARY_NAME:-rnk}"
+version=""
+check_latest=0
+verbosity=${VERBOSITY:-0}
+jq=""
+tdir="."
+target="/usr/local/bin"
+os_id=""
+
+if type -P mktemp > /dev/null; then
+    tdir=$(mktemp -d -t renku-cli-install.XXXXXXX)
+fi
+
+trap cleanup 1 2 3 6 ERR
+
+
+debug() {
+    printf "%s\n" "$*" >&2
+}
+
+debug_v() {
+    [[ $verbosity -eq 0 ]] || debug "$*"
+}
+
+cleanup() {
+    if ! [ "$tdir" == "." ]; then
+        debug_v "Cleanup temporary files: $tdir"
+        rm -rf "$tdir"
+    fi
+    exit
+}
+
+assert_exec() {
+    local program="$1"
+    if ! type -P "$1" >/dev/null; then
+        debug "$1 is not installed. Please install $1 and run this script again."
+        exit 1
+    fi
+}
+
+curl_silent() {
+    if [ "$verbosity" -eq 0 ]; then
+        curl -sSL -o /dev/null --stderr /dev/null --fail "$@"
+    else
+        debug "curl -sSL --fail $@"
+        curl -sSL -o /dev/null --fail "$@"
+    fi
+}
+
+print_help() {
+    debug "Install script for renku-cli for macos and linux"
+    debug
+    debug "Usage: $(basename "$0") [-h][-c][-v <version>]"
+    debug "Options:"
+    debug "  -h   print this help"
+    debug "  -c   check for latest version"
+    debug "  -v   verbose mode"
+    debug "  -t <tag_name>"
+    debug "       Install the given version instead of latest"
+}
+
+find_latest_release_name() {
+    if [ -n "$version" ]; then
+        echo "$version"
+    else
+        # get latest release
+        local latest_response=$(curl -sSL "$api_url_prefix/latest")
+        if [[ -z "$latest_response" ]] || [[ "$latest_response" =~ .*404.* ]]; then
+            debug_v "No latest release. Use nightly."
+            echo "nightly"
+        else
+            debug_v "Latest release response: $latest_response"
+            if [ -z "$jq" ]; then
+                echo $latest_response | tr ',' '\n' | grep "tag_name" | cut -d':' -f2 | tr -d '[:space:]'
+            else
+                echo $latest_response | jq -r '.tag_name'
+            fi
+        fi
+    fi
+}
+
+find_binary_name() {
+    local v=$(echo $version | tr -d 'v')
+    local suffix=""
+    case "$os" in
+        Linux)
+        ;;
+        Darwin)
+            suffix="darwin-"
+            ;;
+        *)
+            debug "Unknown os: $os"
+            exit 1
+    esac
+
+    case "$arch" in
+        x86_64)
+            suffix="${suffix}amd64"
+            ;;
+        aarch64)
+            suffix="${suffix}aarch64"
+            ;;
+        arm64)
+            suffix="${suffix}aarch64"
+            ;;
+        *)
+            debug "Unknown architecture: $arch"
+            exit 1
+    esac
+
+    if [ "$os_id" == "alpine" ]; then
+        suffix="${suffix}-musl"
+    fi
+
+    if [ "$v" == "nightly" ]; then
+        debug_v "Obtain correct version for nightly"
+        v=$(curl -sSL --fail "https://raw.githubusercontent.com/SwissDataScienceCenter/renku-cli/main/Cargo.toml" | grep "^version" | cut -d'=' -f2 | tr -d '[:space:]' | tr -d '"')
+        suffix="${suffix}-$v"
+    else
+        suffix="${suffix}-$v"
+    fi
+
+    echo "rnk_${suffix}"
+}
+
+while getopts "ht:cv" arg; do
+    case $arg in
+        h)
+            print_help
+            exit 0
+            ;;
+        v)
+            verbosity=1
+            ;;
+        t)
+            version=$OPTARG
+            debug_v "Set version: $version"
+            ;;
+        c)
+            check_latest=1
+            ;;
+    esac
+done
+
+## check for jq otherwise use grep
+if ! type -P rjq >/dev/null; then
+    debug_v "jq is not installed, use grep instead"
+else
+    jq="jq"
+fi
+
+# The aarch64 executables won't work on Android
+if [ "$dist" == "Android" ]; then
+    debug "Sorry, Android is not yet supported."
+    exit 1
+fi
+
+## check for curl
+assert_exec "curl"
+## check for cut, grep (should be available)
+assert_exec "cut"
+assert_exec "grep"
+
+if [ -r /etc/os-release ]; then
+    os_id=$(cat /etc/os-release | grep "^ID=" | cut -d'=' -f2 | tr -d '[:space:]')
+fi
+
+if [ $check_latest -eq 1 ]; then
+    debug_v "Check for latest version only"
+    find_latest_release_name
+    exit 0
+else
+    # Check for nixos
+    if [ "$os_id" == "nixos" ]; then
+        debug "For NixOS, please install via:"
+        debug "  nix profile install github:SwissDataScienceCenter/renku-cli"
+        debug "or use the flake in your nixos configuration."
+        debug "See https://github.com/SwissDataScienceCenter/renku-cli/blob/main/docs/install.md#nix"
+    else
+        ## check for sudo first
+        assert_exec "sudo"
+
+        version=$(find_latest_release_name)
+        binary=$(find_binary_name)
+        url="$dl_url_prefix/download/$version/$binary"
+        debug "Getting renku-cli $version..."
+        debug_v "from: $url"
+        curl -# -sSL --fail -o "$tdir/rnk" "$url"
+        chmod 755 "$tdir/rnk"
+
+        debug "Installing to $target"
+        sudo mkdir -p "$target"
+        sudo cp "$tdir/rnk" "$target/$binary_name"
+        debug "Done."
+    fi
+fi
+
+cleanup


### PR DESCRIPTION
The install script is meant as a convenience method to install the cli tool on various systems (many linuxes, macos).

Extends the install manual and add an overlay for NixOS users.