### PR TITLE
Basic support for cloning public projects

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*    @SwissDataScienceCenter/renku-python-maintainers @SwissDataScienceCenter/renku-graph-maintainers

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,9 +61,12 @@ jobs:
           command: run
           args: --release --features user-doc -- user-doc ./docs
 
+  # check installer on main only, as we reach the github api limit too
+  # quickly
   check-installer:
     name: "check installer"
     runs-on: ${{ matrix.os }}
+    if: github.ref == 'refs/heads/main'
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1512,6 +1512,7 @@ dependencies = [
  "serde_json",
  "snafu",
  "tokio",
+ "toml",
  "vergen",
 ]
 
@@ -1686,6 +1687,15 @@ checksum = "4e0d21c9a8cae1235ad58a00c11cb40d4b1e5c784f1ef2c537876ed6ffd8b7c5"
 dependencies = [
  "itoa",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79e674e01f999af37c49f70a6ede167a8a60b2503e56c5599532a65baa5969a0"
+dependencies = [
  "serde",
 ]
 
@@ -1975,6 +1985,40 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "tokio",
+]
+
+[[package]]
+name = "toml"
+version = "0.8.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f49eb2ab21d2f26bd6db7bf383edc527a7ebaee412d17af4d40fdccd442f335"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4badfd56924ae69bcc9039335b2e017639ce3f9b001c393c1b2d1ef846ce2cbf"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d59a3a72298453f564e2b111fa896f8d07fabb36f51f06d7e875fc5e0b5a3ef1"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -2411,6 +2455,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
+
+[[package]]
+name = "winnow"
+version = "0.6.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59b5e5f6c299a3c7890b876a2a587f3115162487e704907d9b6cd29473052ba1"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winreg"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -219,6 +219,11 @@ name = "cc"
 version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74b6a57f98764a267ff415d50a25e6e166f3831a5071af4995296ea97d210490"
+dependencies = [
+ "jobserver",
+ "libc",
+ "once_cell",
+]
 
 [[package]]
 name = "cfg-if"
@@ -640,9 +645,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe739944a5406424e080edccb6add95685130b9f160d5407c639c7df0c5836b0"
+checksum = "152dd546e5bdac80844ce6befabb9af5784ce375cb6cea554aed99fe2d1fb169"
 dependencies = [
  "typenum",
 ]
@@ -663,6 +668,21 @@ name = "gimli"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
+
+[[package]]
+name = "git2"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b903b73e45dc0c6c596f2d37eccece7c1c8bb6e4407b001096387c63d0d93724"
+dependencies = [
+ "bitflags 2.6.0",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "openssl-probe",
+ "openssl-sys",
+ "url",
+]
 
 [[package]]
 name = "hashbrown"
@@ -857,6 +877,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
+name = "jobserver"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2b099aaa34a9751c5bf0878add70444e1ed2dd73f347be99003d4577277de6e"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -876,6 +905,46 @@ name = "libc"
 version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+
+[[package]]
+name = "libgit2-sys"
+version = "0.17.0+1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10472326a8a6477c3c20a64547b0059e4b0d086869eee31e6d7da728a8eb7224"
+dependencies = [
+ "cc",
+ "libc",
+ "libssh2-sys",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+]
+
+[[package]]
+name = "libssh2-sys"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dc8a030b787e2119a731f1951d6a773e2280c660f8ec4b0f5e1505a386e71ee"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c15da26e5af7e25c90b37a2d75cdbf940cf4a55316de9d84c679c9b8bfabf82e"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "linked-hash-map"
@@ -1432,6 +1501,7 @@ dependencies = [
  "console",
  "env_logger",
  "futures",
+ "git2",
  "iso8601-timestamp",
  "log",
  "openssl",
@@ -1511,9 +1581,9 @@ checksum = "976295e77ce332211c0d24d92c0e83e50f5c5f046d11082cea19f3df13a3562d"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.4"
+version = "0.102.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff448f7e92e913c4b7d4c6d8e4540a1724b319b4152b8aef6d4cf8339712b33e"
+checksum = "f9a6fccd794a42c2c105b513a2f62bc3fd8f3ba57a4593677ceb0bd035164d78"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1513,6 +1513,7 @@ dependencies = [
  "snafu",
  "tokio",
  "toml",
+ "url",
  "vergen",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -639,6 +639,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe739944a5406424e080edccb6add95685130b9f160d5407c639c7df0c5836b0"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -829,6 +838,17 @@ name = "is_terminal_polyfill"
 version = "1.70.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8478577c03552c21db0e2724ffb8986a5ce7af88107e6be5d2ee6e158c12800"
+
+[[package]]
+name = "iso8601-timestamp"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d4e5d712dd664b11e778d1cfc06c79ba2700d6bc1771e44fb7b6a4656b487d"
+dependencies = [
+ "generic-array",
+ "serde",
+ "time",
+]
 
 [[package]]
 name = "itoa"
@@ -1412,6 +1432,7 @@ dependencies = [
  "console",
  "env_logger",
  "futures",
+ "iso8601-timestamp",
  "log",
  "openssl",
  "predicates",
@@ -1955,6 +1976,12 @@ name = "typed-arena"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
+
+[[package]]
+name = "typenum"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "unicase"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ snafu = { version = "0.8.4" }
 tokio = { version = "1", features = ["full"] }
 futures = { version = "0.3" }
 regex = { version = "1.10.5" }
+iso8601-timestamp = { version = "0.2.17" }
 comrak = { version = "0.24.1", optional = true }
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ tokio = { version = "1", features = ["full"] }
 futures = { version = "0.3" }
 regex = { version = "1.10.5" }
 iso8601-timestamp = { version = "0.2.17" }
+toml = { version = "0.8.12" }
 git2 = "0.19.0"
 comrak = { version = "0.24.1", optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ tokio = { version = "1", features = ["full"] }
 futures = { version = "0.3" }
 regex = { version = "1.10.5" }
 iso8601-timestamp = { version = "0.2.17" }
+git2 = "0.19.0"
 comrak = { version = "0.24.1", optional = true }
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ regex = { version = "1.10.5" }
 iso8601-timestamp = { version = "0.2.17" }
 toml = { version = "0.8.12" }
 git2 = "0.19.0"
+url = { version = "2.5.1" }
 comrak = { version = "0.24.1", optional = true }
 
 [features]

--- a/flake.nix
+++ b/flake.nix
@@ -187,6 +187,7 @@
         packages = with pkgs; [
           cargo-edit
           cargo-expand
+          tokio-console
           fenixToolChain.rust-analyzer
           fenixToolChain.rustfmt
         ];

--- a/flake.nix
+++ b/flake.nix
@@ -173,7 +173,7 @@
 
         # Additional dev-shell environment variables can be set directly
         # MY_CUSTOM_DEVELOPMENT_VAR = "something else";
-        RENKU_CLI_RENKU_URL = "https://ci-renku-3668.dev.renku.ch";
+        RENKU_CLI_RENKU_URL = "https://ci-renku-3689.dev.renku.ch";
 
         # Enable mold https://github.com/rui314/mold
         CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER = "${pkgs.clang}/bin/clang";

--- a/flake.nix
+++ b/flake.nix
@@ -186,6 +186,7 @@
         # Extra inputs can be added here; cargo and rustc are provided by default.
         packages = with pkgs; [
           cargo-edit
+          cargo-expand
           fenixToolChain.rust-analyzer
           fenixToolChain.rustfmt
         ];

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2,6 +2,7 @@ pub mod cmd;
 pub mod opts;
 pub mod sink;
 
+use self::cmd::project::Error as ProjectError;
 use self::cmd::{CmdError, Context};
 use self::opts::{MainOpts, SubCommand};
 use clap::CommandFactory;
@@ -19,6 +20,10 @@ pub async fn execute_cmd(opts: MainOpts) -> Result<(), CmdError> {
             input.print_completions(&mut app).await;
         }
         SubCommand::Project(input) => input.exec(ctx).await?,
+        SubCommand::Clone(input) => input
+            .exec(ctx)
+            .await
+            .map_err(|source| ProjectError::Clone { source })?,
 
         #[cfg(feature = "user-doc")]
         SubCommand::UserDoc(input) => input.exec(ctx).await?,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -21,7 +21,7 @@ pub async fn execute_cmd(opts: MainOpts) -> Result<(), CmdError> {
         SubCommand::Project(input) => input.exec(ctx).await?,
 
         #[cfg(feature = "user-doc")]
-        SubCommand::UserDoc(input) => input.exec(&ctx).await?,
+        SubCommand::UserDoc(input) => input.exec(ctx).await?,
     };
     Ok(())
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -18,7 +18,7 @@ pub async fn execute_cmd(opts: MainOpts) -> Result<(), CmdError> {
             let mut app = MainOpts::command();
             input.print_completions(&mut app).await;
         }
-        SubCommand::Project(input) => input.exec(&ctx).await?,
+        SubCommand::Project(input) => input.exec(ctx).await?,
 
         #[cfg(feature = "user-doc")]
         SubCommand::UserDoc(input) => input.exec(&ctx).await?,

--- a/src/cli/cmd.rs
+++ b/src/cli/cmd.rs
@@ -12,19 +12,19 @@ use snafu::{ResultExt, Snafu};
 
 const RENKULAB_IO: &str = "https://renkulab.io";
 
-pub struct Context<'a> {
-    pub opts: &'a CommonOpts,
+pub struct Context {
+    pub opts: CommonOpts,
     pub client: Client,
     pub renku_url: String,
 }
 
-impl Context<'_> {
+impl Context {
     pub fn new(opts: &CommonOpts) -> Result<Context, CmdError> {
         let base_url = get_renku_url(opts);
         let client = Client::new(&base_url, proxy_settings(opts), &None, false)
             .context(ContextCreateSnafu)?;
         Ok(Context {
-            opts,
+            opts: opts.clone(),
             client,
             renku_url: base_url,
         })

--- a/src/cli/cmd.rs
+++ b/src/cli/cmd.rs
@@ -6,8 +6,8 @@ pub mod version;
 
 use super::sink::{Error as SinkError, Sink};
 use crate::cli::opts::{CommonOpts, ProxySetting};
+use crate::data::renku_url::RenkuUrl;
 use crate::httpclient::{self, proxy, Client};
-use reqwest::Url;
 use serde::Serialize;
 use snafu::{ResultExt, Snafu};
 
@@ -29,7 +29,7 @@ impl Context {
         })
     }
 
-    pub fn renku_url(&self) -> &Url {
+    pub fn renku_url(&self) -> &RenkuUrl {
         self.client.base_url()
     }
 
@@ -46,7 +46,7 @@ impl Context {
     }
 }
 
-fn get_renku_url(opts: &CommonOpts) -> Result<Url, CmdError> {
+fn get_renku_url(opts: &CommonOpts) -> Result<RenkuUrl, CmdError> {
     match &opts.renku_url {
         Some(u) => {
             log::debug!("Use renku url from arguments: {}", u);
@@ -55,13 +55,13 @@ fn get_renku_url(opts: &CommonOpts) -> Result<Url, CmdError> {
         None => match std::env::var("RENKU_CLI_RENKU_URL").ok() {
             Some(u) => {
                 log::debug!("Use renku url from env RENKU_CLI_RENKU_URL: {}", u);
-                Url::parse(&u).map_err(|e| CmdError::ContextCreate {
+                RenkuUrl::parse(&u).map_err(|e| CmdError::ContextCreate {
                     source: httpclient::Error::UrlParse { source: e },
                 })
             }
             None => {
                 log::debug!("Use renku url: https://renkulab.io");
-                Url::parse(RENKULAB_IO).map_err(|e| CmdError::ContextCreate {
+                RenkuUrl::parse(RENKULAB_IO).map_err(|e| CmdError::ContextCreate {
                     source: httpclient::Error::UrlParse { source: e },
                 })
             }

--- a/src/cli/cmd.rs
+++ b/src/cli/cmd.rs
@@ -35,6 +35,12 @@ impl Context<'_> {
         let fmt = self.opts.format;
         Sink::write(&fmt, value)
     }
+
+    /// A short hand for `Sink::write_err(self.format(), value)`
+    async fn write_err<A: Sink + Serialize>(&self, value: &A) -> Result<(), SinkError> {
+        let fmt = self.opts.format;
+        Sink::write_err(&fmt, value)
+    }
 }
 
 fn get_renku_url(opts: &CommonOpts) -> String {

--- a/src/cli/cmd.rs
+++ b/src/cli/cmd.rs
@@ -33,10 +33,10 @@ impl Context {
         self.client.base_url()
     }
 
-    /// A short hand for `Sink::write(self.format(), value)`
+    /// A short hand for `Sink::write_out(self.format(), value)`
     async fn write_result<A: Sink + Serialize>(&self, value: &A) -> Result<(), SinkError> {
         let fmt = self.opts.format;
-        Sink::write(&fmt, value)
+        Sink::write_out(&fmt, value)
     }
 
     /// A short hand for `Sink::write_err(self.format(), value)`

--- a/src/cli/cmd/project.rs
+++ b/src/cli/cmd/project.rs
@@ -18,7 +18,7 @@ pub struct Input {
 }
 
 impl Input {
-    pub async fn exec<'a>(&self, ctx: &Context<'a>) -> Result<(), Error> {
+    pub async fn exec(&self, ctx: Context) -> Result<(), Error> {
         match &self.subcmd {
             ProjectCommand::Clone(input) => input.exec(ctx).await.context(CloneSnafu),
         }

--- a/src/cli/cmd/project.rs
+++ b/src/cli/cmd/project.rs
@@ -6,6 +6,7 @@ use snafu::{ResultExt, Snafu};
 
 #[derive(Debug, Snafu)]
 pub enum Error {
+    #[snafu(display("Error cloning project: {}", source))]
     Clone { source: clone::Error },
 }
 

--- a/src/cli/cmd/project/clone.rs
+++ b/src/cli/cmd/project/clone.rs
@@ -1,22 +1,83 @@
+use crate::httpclient::data::ProjectDetails;
+
 use super::Context;
+use crate::cli::sink::Error as SinkError;
+use crate::cli::sink::Sink;
+use crate::httpclient::Error as HttpError;
+use crate::util::data::ProjectId;
 
 use clap::Parser;
-use snafu::Snafu;
+use snafu::{ResultExt, Snafu};
+use std::fmt;
+//use std::path::Path;
 
 /// Clone a project
 #[derive(Parser, Debug)]
 pub struct Input {
-    /// The project slug
-    pub slug: String,
-}
-
-impl Input {
-    pub async fn exec<'a>(&self, _ctx: &Context<'a>) -> Result<(), Error> {
-        Ok(())
-    }
+    /// The first argument is the project to clone, identified by
+    /// either its id or the namespace/slug identifier. The second
+    /// argument is optional, defining the target directory to create
+    /// the project in.
+    #[arg(required = true, num_args = 1..=2)]
+    pub project_and_target: Vec<String>,
 }
 
 #[derive(Debug, Snafu)]
 pub enum Error {
-    Dummy,
+    #[snafu(display("An http error occurred: {}", source))]
+    HttpClient { source: HttpError },
+
+    #[snafu(display("Error writing data: {}", source))]
+    WriteResult { source: SinkError },
+
+    #[snafu(display("Error reading project id: {}", source))]
+    ProjectIdParse {
+        source: crate::util::data::ProjectIdParseError,
+    },
 }
+
+impl Input {
+    pub async fn exec<'a>(&self, ctx: &Context<'a>) -> Result<(), Error> {
+        let details = match self.project_id()? {
+            ProjectId::NamespaceSlug { namespace, slug } => ctx
+                .client
+                .get_project_by_slug(&namespace, &slug, ctx.opts.verbose > 1)
+                .await
+                .context(HttpClientSnafu)?,
+            ProjectId::Id(id) => ctx
+                .client
+                .get_project_by_id(&id, ctx.opts.verbose > 1)
+                .await
+                .context(HttpClientSnafu)?,
+        };
+        ctx.write_result(&details).await.context(WriteResultSnafu)?;
+        Ok(())
+    }
+
+    fn project_id(&self) -> Result<ProjectId, Error> {
+        self.project_and_target
+            .first()
+            .unwrap() // clap makes sure there is at least one element (🤞)
+            .parse::<ProjectId>()
+            .context(ProjectIdParseSnafu)
+    }
+}
+
+// fn prepare_directory(project: &ProjectDetails, parent: &Path) -> Result<(), Error> {
+//     Ok(())
+// }
+
+impl fmt::Display for ProjectDetails {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let lines = self
+            .repositories
+            .iter()
+            .fold(String::new(), |a, b| a + "\n  - " + b);
+        write!(
+            f,
+            "Id: {}\nNamespace/Slug: {}/{}\nVisibility: {}\nCreated At: {}\nRepositories:{}",
+            self.id, self.namespace, self.slug, self.visibility, self.creation_date, lines
+        )
+    }
+}
+impl Sink for ProjectDetails {}

--- a/src/cli/cmd/project/clone.rs
+++ b/src/cli/cmd/project/clone.rs
@@ -83,14 +83,15 @@ impl Input {
         };
         if let Some(details) = opt_details {
             let target = self.target_dir()?.join(&details.slug);
-            let renku_project_cfg = RenkuProjectConfig {
-                renku_url: ctx.renku_url.clone(),
-                project: ProjectInfo {
+            let renku_project_cfg = RenkuProjectConfig::new(
+                &ctx.renku_url,
+                ProjectInfo {
                     id: details.id.clone(),
                     namespace: details.namespace.clone(),
                     slug: details.slug.clone(),
                 },
-            };
+            );
+
             ctx.write_err(&SimpleMessage {
                 message: format!(
                     "Cloning {} ({}) into {}...",

--- a/src/cli/cmd/project/clone.rs
+++ b/src/cli/cmd/project/clone.rs
@@ -3,8 +3,9 @@ use crate::project_config::{ProjectConfigError, ProjectInfo, RenkuProjectConfig}
 
 use super::Context;
 use crate::cli::sink::Error as SinkError;
+use crate::data::project_id::{ProjectId, ProjectIdParseError};
+use crate::data::simple_message::SimpleMessage;
 use crate::httpclient::Error as HttpError;
-use crate::util::data::{ProjectId, SimpleMessage};
 use std::sync::Arc;
 
 use clap::Parser;
@@ -41,9 +42,7 @@ pub enum Error {
     WriteResult { source: SinkError },
 
     #[snafu(display("Error reading project id: {}", source))]
-    ProjectIdParse {
-        source: crate::util::data::ProjectIdParseError,
-    },
+    ProjectIdParse { source: ProjectIdParseError },
 
     #[snafu(display("Error getting current directory: {}", source))]
     CurrentDir { source: std::io::Error },
@@ -71,7 +70,7 @@ impl Input {
         if let Some(details) = opt_details {
             let target = self.target_dir()?.join(&details.slug);
             let renku_project_cfg = RenkuProjectConfig::new(
-                ctx.renku_url().as_str(),
+                ctx.renku_url().clone(),
                 ProjectInfo {
                     id: details.id.clone(),
                     namespace: details.namespace.clone(),

--- a/src/cli/cmd/project/clone.rs
+++ b/src/cli/cmd/project/clone.rs
@@ -1,5 +1,5 @@
-use crate::config::{ConfigError, ProjectInfo, RenkuProjectConfig};
 use crate::httpclient::data::ProjectDetails;
+use crate::project_config::{ProjectConfigError, ProjectInfo, RenkuProjectConfig};
 
 use super::Context;
 use crate::cli::sink::Error as SinkError;
@@ -58,7 +58,7 @@ pub enum Error {
     TaskJoin { source: JoinError },
 
     #[snafu(display("Error creating config file: {}", source))]
-    RenkuConfig { source: ConfigError },
+    RenkuConfig { source: ProjectConfigError },
 }
 
 impl Input {

--- a/src/cli/cmd/project/clone.rs
+++ b/src/cli/cmd/project/clone.rs
@@ -19,8 +19,10 @@ use tokio::task::{JoinError, JoinSet};
 /// slug and cloning each code repository into it.
 #[derive(Parser, Debug)]
 pub struct Input {
-    /// The project to clone, identified by either its id or the
-    /// namespace/slug identifier.
+    /// The project to clone, identified by either its id, the
+    /// namespace/slug identifier or the complete url. If a complete
+    /// url is given, it will override any renku-url that might have
+    /// been given otherwise.
     #[arg()]
     pub project_ref: String,
 
@@ -71,6 +73,11 @@ impl Input {
             ProjectId::Id(id) => ctx
                 .client
                 .get_project_by_id(id, ctx.opts.verbose > 1)
+                .await
+                .context(HttpClientSnafu)?,
+            ProjectId::Url(url) => ctx
+                .client
+                .get_project_by_url(url, ctx.opts.verbose > 1)
                 .await
                 .context(HttpClientSnafu)?,
         };

--- a/src/cli/cmd/project/clone.rs
+++ b/src/cli/cmd/project/clone.rs
@@ -75,16 +75,16 @@ impl Input {
                 .get_project_by_id(id, ctx.opts.verbose > 1)
                 .await
                 .context(HttpClientSnafu)?,
-            ProjectId::Url(url) => ctx
+            ProjectId::FullUrl(url) => ctx
                 .client
-                .get_project_by_url(url, ctx.opts.verbose > 1)
+                .get_project_by_url(url.clone(), ctx.opts.verbose > 1)
                 .await
                 .context(HttpClientSnafu)?,
         };
         if let Some(details) = opt_details {
             let target = self.target_dir()?.join(&details.slug);
             let renku_project_cfg = RenkuProjectConfig::new(
-                &ctx.renku_url,
+                ctx.renku_url().as_str(),
                 ProjectInfo {
                     id: details.id.clone(),
                     namespace: details.namespace.clone(),

--- a/src/cli/cmd/userdoc.rs
+++ b/src/cli/cmd/userdoc.rs
@@ -163,7 +163,7 @@ impl Input {
                     entry,
                     output: result,
                 };
-                Sink::write(&fmt, &res).context(WriteResultSnafu)?;
+                Sink::write_out(&fmt, &res).context(WriteResultSnafu)?;
                 Ok(())
             })
             .await?;

--- a/src/cli/cmd/userdoc.rs
+++ b/src/cli/cmd/userdoc.rs
@@ -317,8 +317,6 @@ fn parse_fence_info(info: &str) -> Option<FenceModifier> {
     parts.next().and_then(|s| FenceModifier::from_str(s).ok())
 }
 
-impl Sink for PathEntry {}
-
 #[derive(Debug, Serialize)]
 struct Processed {
     pub entry: PathEntry,

--- a/src/cli/cmd/userdoc.rs
+++ b/src/cli/cmd/userdoc.rs
@@ -262,6 +262,7 @@ fn run_cli_command(cli: &Path, line: &str) -> Result<String, Error> {
     let mut args = line.split_whitespace();
     args.next(); // skip first word which is the binary name
     let remain: Vec<&str> = args.collect();
+    // TODO use tokio::process instead
     let cmd = Command::new(cli)
         .args(remain)
         .output()

--- a/src/cli/cmd/version.rs
+++ b/src/cli/cmd/version.rs
@@ -76,4 +76,3 @@ impl fmt::Display for Versions<'_> {
 }
 
 impl Sink for Versions<'_> {}
-impl Sink for BuildInfo {}

--- a/src/cli/cmd/version.rs
+++ b/src/cli/cmd/version.rs
@@ -31,7 +31,7 @@ pub enum Error {
 }
 
 impl Input {
-    pub async fn exec<'a>(&self, ctx: &Context<'a>) -> Result<(), Error> {
+    pub async fn exec(&self, ctx: &Context) -> Result<(), Error> {
         if self.client_only {
             let vinfo = BuildInfo::default();
             ctx.write_result(&vinfo).await.context(WriteResultSnafu)?;

--- a/src/cli/cmd/version.rs
+++ b/src/cli/cmd/version.rs
@@ -41,7 +41,8 @@ impl Input {
                 .version(ctx.opts.verbose > 1)
                 .await
                 .context(HttpClientSnafu)?;
-            let vinfo = Versions::create(result, &ctx.renku_url);
+            let urlstr = ctx.renku_url().as_str();
+            let vinfo = Versions::create(result, urlstr);
             ctx.write_result(&vinfo).await.context(WriteResultSnafu)?;
         }
         Ok(())

--- a/src/cli/opts.rs
+++ b/src/cli/opts.rs
@@ -62,8 +62,8 @@ pub enum SubCommand {
 /// them. Each sub command has its own set of flags/options and
 /// arguments.
 ///
-/// Repository: https://github.com/SwissDataScienceCenter/renku-cli
-/// Issue tracker: https://github.com/SwissDataScienceCenter/renku-cli/issues
+/// Repository: <https://github.com/SwissDataScienceCenter/renku-cli>
+/// Issue tracker: <https://github.com/SwissDataScienceCenter/renku-cli/issues>
 #[derive(Parser, Debug)]
 #[command(name = "rnk", version)]
 pub struct MainOpts {

--- a/src/cli/opts.rs
+++ b/src/cli/opts.rs
@@ -54,6 +54,10 @@ pub enum SubCommand {
     #[command()]
     Project(project::Input),
 
+    /// Clone a project. (Shortcut for 'project clone')
+    #[command()]
+    Clone(project::clone::Input),
+
     #[cfg(feature = "user-doc")]
     UserDoc(userdoc::Input),
 }

--- a/src/cli/opts.rs
+++ b/src/cli/opts.rs
@@ -5,7 +5,7 @@ use std::str::FromStr;
 
 /// Main options are available to all commands. They must appear
 /// before a sub-command.
-#[derive(Parser, Debug)]
+#[derive(Parser, Debug, Clone)]
 #[command()]
 pub struct CommonOpts {
     /// Be more verbose when logging. Verbosity increases with each

--- a/src/cli/opts.rs
+++ b/src/cli/opts.rs
@@ -1,6 +1,7 @@
+use crate::data::renku_url::RenkuUrl;
+
 use super::cmd::*;
 use clap::{ArgAction, Parser, ValueEnum, ValueHint};
-use reqwest::Url;
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 
@@ -24,7 +25,7 @@ pub struct CommonOpts {
     /// The (base) URL to Renku. It can be given as environment
     /// variable RENKU_CLI_RENKU_URL.
     #[arg(long, value_hint = ValueHint::Url)]
-    pub renku_url: Option<Url>,
+    pub renku_url: Option<RenkuUrl>,
 
     /// Set a proxy to use for doing http requests. By default, the
     /// system proxy will be used. Can be either `none` or <url>. If

--- a/src/cli/opts.rs
+++ b/src/cli/opts.rs
@@ -1,5 +1,6 @@
 use super::cmd::*;
 use clap::{ArgAction, Parser, ValueEnum, ValueHint};
+use reqwest::Url;
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 
@@ -23,7 +24,7 @@ pub struct CommonOpts {
     /// The (base) URL to Renku. It can be given as environment
     /// variable RENKU_CLI_RENKU_URL.
     #[arg(long, value_hint = ValueHint::Url)]
-    pub renku_url: Option<String>,
+    pub renku_url: Option<Url>,
 
     /// Set a proxy to use for doing http requests. By default, the
     /// system proxy will be used. Can be either `none` or <url>. If

--- a/src/cli/sink.rs
+++ b/src/cli/sink.rs
@@ -1,6 +1,6 @@
 use crate::cli::opts::Format;
+use crate::data::simple_message::SimpleMessage;
 use crate::httpclient::data::*;
-use crate::util::data::*;
 use crate::util::file::PathEntry;
 use serde::Serialize;
 use snafu::Snafu;

--- a/src/cli/sink.rs
+++ b/src/cli/sink.rs
@@ -1,7 +1,12 @@
 use crate::cli::opts::Format;
+use crate::httpclient::data::*;
+use crate::util::data::*;
+use crate::util::file::PathEntry;
 use serde::Serialize;
 use snafu::Snafu;
 use std::fmt::Display;
+
+use super::BuildInfo;
 
 #[derive(Debug, Snafu)]
 pub enum Error {
@@ -24,6 +29,18 @@ where
             }
         }
     }
+    fn write_err(format: &Format, value: &Self) -> Result<(), Error> {
+        match format {
+            Format::Json => {
+                serde_json::to_writer(std::io::stderr(), value)?;
+                Ok(())
+            }
+            Format::Default => {
+                eprintln!("{}", value);
+                Ok(())
+            }
+        }
+    }
 }
 
 impl From<serde_json::Error> for Error {
@@ -31,3 +48,8 @@ impl From<serde_json::Error> for Error {
         Error::Json { source: e }
     }
 }
+
+impl Sink for ProjectDetails {}
+impl Sink for SimpleMessage {}
+impl Sink for BuildInfo {}
+impl Sink for PathEntry {}

--- a/src/cli/sink.rs
+++ b/src/cli/sink.rs
@@ -17,7 +17,7 @@ pub trait Sink
 where
     Self: Serialize + Display,
 {
-    fn write(format: &Format, value: &Self) -> Result<(), Error> {
+    fn write_out(format: &Format, value: &Self) -> Result<(), Error> {
         match format {
             Format::Json => {
                 serde_json::to_writer(std::io::stdout(), value)?;

--- a/src/config.rs
+++ b/src/config.rs
@@ -89,7 +89,7 @@ fn write_and_read_config() {
             slug: "projecta".into(),
         },
     };
-    let target: PathBuf = "test.conf".into();
+    let target: PathBuf = "/tmp/test.conf".into();
     data.write(&target).unwrap();
     let from_file = RenkuProjectConfig::read(&target).unwrap();
     std::fs::remove_file(&target).unwrap();

--- a/src/config.rs
+++ b/src/config.rs
@@ -28,6 +28,9 @@ pub enum ConfigError {
 
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 pub struct RenkuProjectConfig {
+    /// The version of this config file.
+    version: u16,
+
     /// The base url to the renku platform.
     pub renku_url: String,
 
@@ -43,6 +46,14 @@ pub struct ProjectInfo {
 }
 
 impl RenkuProjectConfig {
+    pub fn new<S: AsRef<str>>(renku_url: S, project: ProjectInfo) -> RenkuProjectConfig {
+        RenkuProjectConfig {
+            version: 1,
+            renku_url: renku_url.as_ref().into(),
+            project,
+        }
+    }
+
     pub fn read(file: &Path) -> Result<RenkuProjectConfig, ConfigError> {
         let cnt = std::fs::read_to_string(file).map_err(|e| ConfigError::ReadFile {
             source: e,
@@ -82,6 +93,7 @@ impl RenkuProjectConfig {
 #[test]
 fn write_and_read_config() {
     let data = RenkuProjectConfig {
+        version: 1,
         renku_url: "http://renkulab.io".into(),
         project: ProjectInfo {
             id: "abc123".into(),

--- a/src/config.rs
+++ b/src/config.rs
@@ -89,7 +89,8 @@ fn write_and_read_config() {
             slug: "projecta".into(),
         },
     };
-    let target: PathBuf = "/tmp/test.conf".into();
+    let tmp = std::env::temp_dir();
+    let target = tmp.join("test.conf");
     data.write(&target).unwrap();
     let from_file = RenkuProjectConfig::read(&target).unwrap();
     std::fs::remove_file(&target).unwrap();

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,97 @@
+use serde::{Deserialize, Serialize};
+use snafu::Snafu;
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Snafu)]
+pub enum ConfigError {
+    #[snafu(display("Unable to read config file {}: {}", path.display(), source))]
+    ReadFile {
+        source: std::io::Error,
+        path: PathBuf,
+    },
+    #[snafu(display("Unable to write config file {}: {}", path.display(), source))]
+    WriteFile {
+        source: std::io::Error,
+        path: PathBuf,
+    },
+    #[snafu(display("Unable to parse file {}: {}", path.display(), source))]
+    ParseFile {
+        source: toml::de::Error,
+        path: PathBuf,
+    },
+    #[snafu(display("The config file could not be serialized"))]
+    WriteToml {
+        source: toml::ser::Error,
+        path: PathBuf,
+    },
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+pub struct RenkuProjectConfig {
+    /// The base url to the renku platform.
+    pub renku_url: String,
+
+    /// Information about the project
+    pub project: ProjectInfo,
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+pub struct ProjectInfo {
+    pub id: String,
+    pub namespace: String,
+    pub slug: String,
+}
+
+impl RenkuProjectConfig {
+    pub fn read(file: &Path) -> Result<RenkuProjectConfig, ConfigError> {
+        let cnt = std::fs::read_to_string(file).map_err(|e| ConfigError::ReadFile {
+            source: e,
+            path: file.to_path_buf(),
+        });
+        cnt.and_then(|c| {
+            toml::from_str(&c).map_err(|e| ConfigError::ParseFile {
+                source: e,
+                path: file.to_path_buf(),
+            })
+        })
+    }
+
+    pub fn write(&self, file: &Path) -> Result<(), ConfigError> {
+        if !file.exists() {
+            if let Some(dir) = file.parent() {
+                std::fs::create_dir_all(dir).map_err(|e| ConfigError::WriteFile {
+                    source: e,
+                    path: file.to_path_buf(),
+                })?;
+            }
+        }
+        let cnt = toml::to_string(self).map_err(|e| ConfigError::WriteToml {
+            source: e,
+            path: file.to_path_buf(),
+        });
+
+        cnt.and_then(|c| {
+            std::fs::write(file, c).map_err(|e| ConfigError::WriteFile {
+                source: e,
+                path: file.to_path_buf(),
+            })
+        })
+    }
+}
+
+#[test]
+fn write_and_read_config() {
+    let data = RenkuProjectConfig {
+        renku_url: "http://renkulab.io".into(),
+        project: ProjectInfo {
+            id: "abc123".into(),
+            namespace: "my-ns".into(),
+            slug: "projecta".into(),
+        },
+    };
+    let target: PathBuf = "test.conf".into();
+    data.write(&target).unwrap();
+    let from_file = RenkuProjectConfig::read(&target).unwrap();
+    std::fs::remove_file(&target).unwrap();
+    assert_eq!(data, from_file);
+}

--- a/src/data.rs
+++ b/src/data.rs
@@ -1,0 +1,9 @@
+/*!
+
+Data types used across the cli
+
+*/
+
+pub mod project_id;
+pub mod renku_url;
+pub mod simple_message;

--- a/src/data/renku_url.rs
+++ b/src/data/renku_url.rs
@@ -1,0 +1,69 @@
+use std::{fmt::Display, str::FromStr};
+
+use reqwest::Url;
+use serde::{Deserialize, Serialize};
+use url::ParseError;
+
+// Need this newtype to be able to implement Serialize and Deserialize
+
+#[derive(Debug, PartialEq, Clone)]
+pub struct RenkuUrl(Url);
+
+impl RenkuUrl {
+    pub fn new(url: Url) -> RenkuUrl {
+        RenkuUrl(url)
+    }
+
+    pub fn parse(s: &str) -> Result<RenkuUrl, ParseError> {
+        s.parse::<RenkuUrl>()
+    }
+
+    pub fn as_url(&self) -> &Url {
+        let RenkuUrl(u) = self;
+        u
+    }
+
+    pub fn as_str(&self) -> &str {
+        let RenkuUrl(u) = self;
+        u.as_str()
+    }
+
+    pub fn join(&self, seg: &str) -> Result<RenkuUrl, ParseError> {
+        let RenkuUrl(u) = self;
+        u.join(seg).map(RenkuUrl)
+    }
+}
+
+impl<'de> Deserialize<'de> for RenkuUrl {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        let u = RenkuUrl::from_str(&s).map_err(serde::de::Error::custom)?;
+        Ok(u)
+    }
+}
+
+impl Serialize for RenkuUrl {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let RenkuUrl(u) = self;
+        serializer.serialize_str(u.as_str())
+    }
+}
+impl Display for RenkuUrl {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
+impl FromStr for RenkuUrl {
+    type Err = ParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Url::parse(s).map(RenkuUrl)
+    }
+}

--- a/src/data/simple_message.rs
+++ b/src/data/simple_message.rs
@@ -1,0 +1,14 @@
+use std::fmt;
+
+use serde::Serialize;
+
+#[derive(Debug, Serialize)]
+pub struct SimpleMessage {
+    pub message: String,
+}
+
+impl fmt::Display for SimpleMessage {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}

--- a/src/httpclient.rs
+++ b/src/httpclient.rs
@@ -153,6 +153,7 @@ impl Client {
         slug: &str,
         debug: bool,
     ) -> Result<ProjectDetails, Error> {
+        log::debug!("Get project by namespace/slug: {}/{}", namespace, slug);
         let path = format!("/api/data/projects/{}/{}", namespace, slug);
         let details = self.json_get::<ProjectDetails>(&path, debug).await?;
         Ok(details)
@@ -160,6 +161,7 @@ impl Client {
 
     /// Get project details by project id.
     pub async fn get_project_by_id(&self, id: &str, debug: bool) -> Result<ProjectDetails, Error> {
+        log::debug!("Get project by id: {}", id);
         let path = format!("/api/data/projects/{}", id);
         let details = self.json_get::<ProjectDetails>(&path, debug).await?;
         Ok(details)

--- a/src/httpclient.rs
+++ b/src/httpclient.rs
@@ -6,8 +6,10 @@
 //!
 //! ```rust
 //! use rnk::httpclient;
+//! use rnk::data::renku_url::RenkuUrl;
+//!
 //! let client = httpclient::Client::new(
-//!    "https://renkulab.io",
+//!    RenkuUrl::parse("https://renkulab.io").unwrap(),
 //!    httpclient::proxy::ProxySetting::System,
 //!    None,
 //!    false

--- a/src/httpclient.rs
+++ b/src/httpclient.rs
@@ -135,7 +135,10 @@ impl Client {
         path: &str,
         debug: bool,
     ) -> Result<Option<R>, Error> {
-        let url = &format!("{}{}", self.base_url, path);
+        let mut url: &str = &format!("{}{}", self.base_url, path);
+        if path.starts_with("http") {
+            url = path;
+        }
         let resp = self
             .client
             .get(url)
@@ -192,6 +195,24 @@ impl Client {
     ) -> Result<Option<ProjectDetails>, Error> {
         log::debug!("Get project by id: {}", id);
         let path = format!("/api/data/projects/{}", id);
+        let details = self.json_get_option::<ProjectDetails>(&path, debug).await?;
+        Ok(details)
+    }
+
+    pub async fn get_project_by_url(
+        &self,
+        url: &str,
+        debug: bool,
+    ) -> Result<Option<ProjectDetails>, Error> {
+        log::debug!("Get project by url: {}", url);
+        // there are different urls identifying the project
+        //   /api/data/projects/<id>
+        //   /api/data/projects/<namespace>/<slug>
+        //   /v2/projects/<id> (ui)
+        //   /v2/projects/<namespace>/<slug> (ui)
+        // the api is only the first two. Try to replace `v2` with `api/data`
+        let path = url.replace("/v2/", "/api/data/");
+        log::debug!("Transformed url to: {}", path);
         let details = self.json_get_option::<ProjectDetails>(&path, debug).await?;
         Ok(details)
     }

--- a/src/httpclient.rs
+++ b/src/httpclient.rs
@@ -145,4 +145,23 @@ impl Client {
             .await?;
         Ok(VersionInfo { search, data })
     }
+
+    /// Get project details given the namespace and slug.
+    pub async fn get_project_by_slug(
+        &self,
+        namespace: &str,
+        slug: &str,
+        debug: bool,
+    ) -> Result<ProjectDetails, Error> {
+        let path = format!("/api/data/projects/{}/{}", namespace, slug);
+        let details = self.json_get::<ProjectDetails>(&path, debug).await?;
+        Ok(details)
+    }
+
+    /// Get project details by project id.
+    pub async fn get_project_by_id(&self, id: &str, debug: bool) -> Result<ProjectDetails, Error> {
+        let path = format!("/api/data/projects/{}", id);
+        let details = self.json_get::<ProjectDetails>(&path, debug).await?;
+        Ok(details)
+    }
 }

--- a/src/httpclient.rs
+++ b/src/httpclient.rs
@@ -9,7 +9,7 @@
 //! let client = httpclient::Client::new(
 //!    "https://renkulab.io",
 //!    httpclient::proxy::ProxySetting::System,
-//!    &None,
+//!    None,
 //!    false
 //! ).unwrap();
 //! async {

--- a/src/httpclient.rs
+++ b/src/httpclient.rs
@@ -24,6 +24,8 @@
 pub mod data;
 pub mod proxy;
 
+use crate::util::data::ProjectId;
+
 use self::data::*;
 use reqwest::Certificate;
 use reqwest::ClientBuilder;
@@ -198,6 +200,21 @@ impl Client {
             .json_get::<SearchServiceVersion>("/ui-server/api/search/version", debug)
             .await?;
         Ok(VersionInfo { search, data })
+    }
+
+    pub async fn get_project(
+        &self,
+        id: &ProjectId,
+        debug: bool,
+    ) -> Result<Option<ProjectDetails>, Error> {
+        match id {
+            ProjectId::NamespaceSlug { namespace, slug } => {
+                self.get_project_by_slug(namespace, slug, debug).await
+            }
+            ProjectId::Id(pid) => self.get_project_by_id(pid, debug).await,
+
+            ProjectId::FullUrl(url) => self.get_project_by_url(url.clone(), debug).await,
+        }
     }
 
     /// Get project details given the namespace and slug.

--- a/src/httpclient/data.rs
+++ b/src/httpclient/data.rs
@@ -59,3 +59,16 @@ pub struct ProjectDetails {
     pub keywords: Vec<String>,
     pub creation_date: Timestamp,
 }
+impl fmt::Display for ProjectDetails {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let lines = self
+            .repositories
+            .iter()
+            .fold(String::new(), |a, b| a + "\n  - " + b);
+        write!(
+            f,
+            "Id: {}\nNamespace/Slug: {}/{}\nVisibility: {}\nCreated At: {}\nRepositories:{}",
+            self.id, self.namespace, self.slug, self.visibility, self.creation_date, lines
+        )
+    }
+}

--- a/src/httpclient/data.rs
+++ b/src/httpclient/data.rs
@@ -12,17 +12,16 @@ pub enum Visibility {
     #[serde(alias = "private")]
     Private,
 }
-impl Visibility {
-    pub fn as_string(&self) -> &str {
-        match self {
-            Visibility::Private => "private",
-            Visibility::Public => "public",
-        }
-    }
-}
 impl fmt::Display for Visibility {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.as_string())
+        write!(
+            f,
+            "{}",
+            match self {
+                Visibility::Private => "private",
+                Visibility::Public => "public",
+            }
+        )
     }
 }
 

--- a/src/httpclient/data.rs
+++ b/src/httpclient/data.rs
@@ -1,7 +1,30 @@
 //! Defines data structures for requests and responses and their
 //! `De/Serialize` instances.
 
+use iso8601_timestamp::Timestamp;
 use serde::{Deserialize, Serialize};
+use std::fmt;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub enum Visibility {
+    #[serde(alias = "public")]
+    Public,
+    #[serde(alias = "private")]
+    Private,
+}
+impl Visibility {
+    pub fn as_string(&self) -> &str {
+        match self {
+            Visibility::Private => "private",
+            Visibility::Public => "public",
+        }
+    }
+}
+impl fmt::Display for Visibility {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.as_string())
+    }
+}
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct SearchServiceVersion {
@@ -21,4 +44,18 @@ pub struct SimpleVersion {
 pub struct VersionInfo {
     pub search: SearchServiceVersion,
     pub data: SimpleVersion,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ProjectDetails {
+    pub id: String,
+    pub name: String,
+    pub namespace: String,
+    pub slug: String,
+    pub visibility: Visibility,
+    pub etag: Option<String>,
+    pub repositories: Vec<String>,
+    pub description: Option<String>,
+    pub keywords: Vec<String>,
+    pub creation_date: Timestamp,
 }

--- a/src/httpclient/proxy.rs
+++ b/src/httpclient/proxy.rs
@@ -1,6 +1,7 @@
 use reqwest::ClientBuilder;
 use reqwest::{Proxy, Result};
 
+#[derive(Debug, Clone)]
 pub enum ProxySetting {
     System,
     None,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod cli;
+pub mod data;
 pub mod error;
 pub mod httpclient;
 pub mod project_config;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 pub mod cli;
-pub mod config;
 pub mod error;
 pub mod httpclient;
+pub mod project_config;
 pub mod util;
 
 pub use cli::execute_cmd;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod cli;
+pub mod config;
 pub mod error;
 pub mod httpclient;
 pub mod util;

--- a/src/project_config.rs
+++ b/src/project_config.rs
@@ -2,6 +2,8 @@ use serde::{Deserialize, Serialize};
 use snafu::Snafu;
 use std::path::{Path, PathBuf};
 
+use crate::data::renku_url::RenkuUrl;
+
 #[derive(Debug, Snafu)]
 pub enum ProjectConfigError {
     #[snafu(display("Unable to read config file {}: {}", path.display(), source))]
@@ -32,7 +34,7 @@ pub struct RenkuProjectConfig {
     version: u16,
 
     /// The base url to the renku platform.
-    pub renku_url: String,
+    pub renku_url: RenkuUrl,
 
     /// Information about the project
     pub project: ProjectInfo,
@@ -46,10 +48,10 @@ pub struct ProjectInfo {
 }
 
 impl RenkuProjectConfig {
-    pub fn new<S: AsRef<str>>(renku_url: S, project: ProjectInfo) -> RenkuProjectConfig {
+    pub fn new(renku_url: RenkuUrl, project: ProjectInfo) -> RenkuProjectConfig {
         RenkuProjectConfig {
             version: 1,
-            renku_url: renku_url.as_ref().into(),
+            renku_url,
             project,
         }
     }
@@ -94,7 +96,7 @@ impl RenkuProjectConfig {
 fn write_and_read_config() {
     let data = RenkuProjectConfig {
         version: 1,
-        renku_url: "http://renkulab.io".into(),
+        renku_url: RenkuUrl::parse("http://renkulab.io").unwrap(),
         project: ProjectInfo {
             id: "abc123".into(),
             namespace: "my-ns".into(),

--- a/src/project_config.rs
+++ b/src/project_config.rs
@@ -3,7 +3,7 @@ use snafu::Snafu;
 use std::path::{Path, PathBuf};
 
 #[derive(Debug, Snafu)]
-pub enum ConfigError {
+pub enum ProjectConfigError {
     #[snafu(display("Unable to read config file {}: {}", path.display(), source))]
     ReadFile {
         source: std::io::Error,
@@ -54,35 +54,35 @@ impl RenkuProjectConfig {
         }
     }
 
-    pub fn read(file: &Path) -> Result<RenkuProjectConfig, ConfigError> {
-        let cnt = std::fs::read_to_string(file).map_err(|e| ConfigError::ReadFile {
+    pub fn read(file: &Path) -> Result<RenkuProjectConfig, ProjectConfigError> {
+        let cnt = std::fs::read_to_string(file).map_err(|e| ProjectConfigError::ReadFile {
             source: e,
             path: file.to_path_buf(),
         });
         cnt.and_then(|c| {
-            toml::from_str(&c).map_err(|e| ConfigError::ParseFile {
+            toml::from_str(&c).map_err(|e| ProjectConfigError::ParseFile {
                 source: e,
                 path: file.to_path_buf(),
             })
         })
     }
 
-    pub fn write(&self, file: &Path) -> Result<(), ConfigError> {
+    pub fn write(&self, file: &Path) -> Result<(), ProjectConfigError> {
         if !file.exists() {
             if let Some(dir) = file.parent() {
-                std::fs::create_dir_all(dir).map_err(|e| ConfigError::WriteFile {
+                std::fs::create_dir_all(dir).map_err(|e| ProjectConfigError::WriteFile {
                     source: e,
                     path: file.to_path_buf(),
                 })?;
             }
         }
-        let cnt = toml::to_string(self).map_err(|e| ConfigError::WriteToml {
+        let cnt = toml::to_string(self).map_err(|e| ProjectConfigError::WriteToml {
             source: e,
             path: file.to_path_buf(),
         });
 
         cnt.and_then(|c| {
-            std::fs::write(file, c).map_err(|e| ConfigError::WriteFile {
+            std::fs::write(file, c).map_err(|e| ProjectConfigError::WriteFile {
                 source: e,
                 path: file.to_path_buf(),
             })

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,6 @@
+/*!
+
+Utility functions.
+
+ */
+pub mod file;

--- a/src/util/data.rs
+++ b/src/util/data.rs
@@ -1,0 +1,44 @@
+use std::fmt;
+use std::str;
+
+use snafu::Snafu;
+
+#[derive(Debug)]
+pub enum ProjectId {
+    NamespaceSlug { namespace: String, slug: String },
+    Id(String),
+}
+
+impl ProjectId {
+    pub fn as_string(&self) -> String {
+        match self {
+            ProjectId::NamespaceSlug { namespace, slug } => {
+                format!("{}/{}", namespace, slug)
+            }
+            ProjectId::Id(id) => id.to_string(),
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Snafu)]
+pub struct ProjectIdParseError;
+
+impl str::FromStr for ProjectId {
+    type Err = ProjectIdParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.split_once('/') {
+            Some((pre, suf)) => Ok(ProjectId::NamespaceSlug {
+                namespace: pre.into(),
+                slug: suf.into(),
+            }),
+            None => Ok(ProjectId::Id(s.to_string())),
+        }
+    }
+}
+
+impl fmt::Display for ProjectId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.as_string())
+    }
+}

--- a/src/util/data.rs
+++ b/src/util/data.rs
@@ -8,6 +8,7 @@ use snafu::Snafu;
 pub enum ProjectId {
     NamespaceSlug { namespace: String, slug: String },
     Id(String),
+    Url(String),
 }
 
 impl ProjectId {
@@ -17,6 +18,7 @@ impl ProjectId {
                 format!("{}/{}", namespace, slug)
             }
             ProjectId::Id(id) => id.to_string(),
+            ProjectId::Url(url) => url.to_string(),
         }
     }
 }
@@ -28,12 +30,16 @@ impl str::FromStr for ProjectId {
     type Err = ProjectIdParseError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s.split_once('/') {
-            Some((pre, suf)) => Ok(ProjectId::NamespaceSlug {
-                namespace: pre.into(),
-                slug: suf.into(),
-            }),
-            None => Ok(ProjectId::Id(s.to_string())),
+        if s.starts_with("http") {
+            Ok(ProjectId::Url(s.to_string()))
+        } else {
+            match s.split_once('/') {
+                Some((pre, suf)) => Ok(ProjectId::NamespaceSlug {
+                    namespace: pre.into(),
+                    slug: suf.into(),
+                }),
+                None => Ok(ProjectId::Id(s.to_string())),
+            }
         }
     }
 }

--- a/src/util/data.rs
+++ b/src/util/data.rs
@@ -5,7 +5,7 @@ use serde::Serialize;
 use snafu::{ResultExt, Snafu};
 use url::{ParseError as UrlParseError, Url};
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum ProjectId {
     NamespaceSlug { namespace: String, slug: String },
     Id(String),

--- a/src/util/data.rs
+++ b/src/util/data.rs
@@ -1,6 +1,7 @@
 use std::fmt;
 use std::str;
 
+use serde::Serialize;
 use snafu::Snafu;
 
 #[derive(Debug)]
@@ -40,5 +41,16 @@ impl str::FromStr for ProjectId {
 impl fmt::Display for ProjectId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.as_string())
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct SimpleMessage {
+    pub message: String,
+}
+
+impl fmt::Display for SimpleMessage {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.message)
     }
 }

--- a/src/util/data.rs
+++ b/src/util/data.rs
@@ -12,18 +12,6 @@ pub enum ProjectId {
     FullUrl(Url),
 }
 
-impl ProjectId {
-    pub fn as_string(&self) -> String {
-        match self {
-            ProjectId::NamespaceSlug { namespace, slug } => {
-                format!("{}/{}", namespace, slug)
-            }
-            ProjectId::Id(id) => id.to_string(),
-            ProjectId::FullUrl(url) => url.to_string(),
-        }
-    }
-}
-
 #[derive(Debug, PartialEq, Snafu)]
 pub enum ProjectIdParseError {
     UrlParse { source: UrlParseError },
@@ -50,7 +38,17 @@ impl str::FromStr for ProjectId {
 
 impl fmt::Display for ProjectId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.as_string())
+        write!(
+            f,
+            "{}",
+            match self {
+                ProjectId::NamespaceSlug { namespace, slug } => {
+                    format!("{}/{}", namespace, slug)
+                }
+                ProjectId::Id(id) => id.to_string(),
+                ProjectId::FullUrl(url) => url.to_string(),
+            }
+        )
     }
 }
 

--- a/src/util/file.rs
+++ b/src/util/file.rs
@@ -57,6 +57,7 @@ where
         .flatten()
 }
 
+//TODO look at tokio-stream crate, that provides wrappers for implementing Stream for tokio::ReadDir
 /// Visits all entries of the given paths recursively using tokios async read_dir.
 pub fn visit_all<I, P>(paths: I) -> impl Stream<Item = io::Result<PathBuf>> + Send + 'static
 where

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,2 +1,0 @@
-pub mod data;
-pub mod file;

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,1 +1,2 @@
+pub mod data;
 pub mod file;


### PR DESCRIPTION
Allows to clone a renku project by cloning all its git repositories (it assumes git).

Running:
```
rnk project clone <project-ref> #or, alternative shortcut
rnk clone <project-ref>
```
gets the project from data-services, and git-clones all its repositories to the local file system. It also writes a file in `.renku/config.toml` containing the information about the origin of the project.

The `<project-ref>` can be the project `id`, its `namespace/slug` identifier or a complete url (copied from the browser).