### PR TITLE
fix: cloning repositories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -977,6 +977,8 @@ dependencies = [
  "libc",
  "libgit2-sys",
  "log",
+ "openssl-probe",
+ "openssl-sys",
  "url",
 ]
 
@@ -1209,6 +1211,19 @@ dependencies = [
 
 [[package]]
 name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper 0.14.30",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+]
+
+[[package]]
+name = "hyper-tls"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
@@ -1383,7 +1398,9 @@ checksum = "10472326a8a6477c3c20a64547b0059e4b0d086869eee31e6d7da728a8eb7224"
 dependencies = [
  "cc",
  "libc",
+ "libssh2-sys",
  "libz-sys",
+ "openssl-sys",
  "pkg-config",
 ]
 
@@ -1401,6 +1418,20 @@ checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
  "bitflags 2.6.0",
  "libc",
+]
+
+[[package]]
+name = "libssh2-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "220e4f05ad4a218192533b300327f5150e809b54c4ec83b5a1d91833601811b9"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -2082,10 +2113,12 @@ dependencies = [
  "http-body 0.4.6",
  "hyper 0.14.30",
  "hyper-rustls 0.24.2",
+ "hyper-tls 0.5.0",
  "ipnet",
  "js-sys",
  "log",
  "mime",
+ "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -2097,6 +2130,7 @@ dependencies = [
  "sync_wrapper 0.1.2",
  "system-configuration",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls 0.24.1",
  "tower-service",
  "url",
@@ -2122,7 +2156,7 @@ dependencies = [
  "http-body-util",
  "hyper 1.4.1",
  "hyper-rustls 0.27.2",
- "hyper-tls",
+ "hyper-tls 0.6.0",
  "hyper-util",
  "ipnet",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,16 +29,16 @@ futures = { version = "0.3" }
 regex = { version = "1.11.0" }
 iso8601-timestamp = { version = "0.2.17" }
 toml = { version = "0.8.19" }
-git2 = { version = "0.19.0", default-features = false, features = [ "vendored-libgit2" ]}
+git2 = { version = "0.19.0", default-features = false, features = [ "ssh", "https", "vendored-libgit2" ]}
 url = { version = "2.5.1" }
 openidconnect = { version = "3.5.0", default-features = false, features = [ "reqwest" ] }
 directories = { version = "5.0" }
 comrak = { version = "0.28.0", optional = true }
 
 [features]
-default = ["reqwest/default-tls"] # link against system library
+default = ["reqwest/default-tls", "openidconnect/native-tls"] # link against system library
 rustls = ["reqwest/rustls-tls", "openidconnect/rustls-tls"] # include rustls, ssl library written in rust
-vendored-openssl = ["openssl/vendored"] # include compiled openssl library
+vendored-openssl = ["git2/vendored-openssl", "reqwest/native-tls-vendored"] # include compiled openssl library
 user-doc = [ "dep:comrak" ]
 
 [dev-dependencies]


### PR DESCRIPTION
Before this any compilation feature would not work on my computer when it came to cloning a repository.

And the error would consistenly be:

```
Project - Error cloning project: Error cloning project: there is no TLS stream available; class=Ssl (16)
```