### PR TITLE
feat: add a `--wait` option to the job start command

### DIFF
--- a/src/cli/cmd/job/logs.rs
+++ b/src/cli/cmd/job/logs.rs
@@ -38,19 +38,15 @@ pub enum Error {
 impl Input {
     pub async fn exec(&self, ctx: Context) -> Result<(), Error> {
         if self.follow {
-            self.follow_logs(ctx).await
+            self.follow_logs(ctx).await.context(HttpClientSnafu)
         } else {
-            self.show_logs(&ctx, 0).await?;
+            self.show_logs(&ctx, 0).await.context(HttpClientSnafu)?;
             Ok(())
         }
     }
 
-    async fn show_logs(&self, ctx: &Context, seen: usize) -> Result<usize, Error> {
-        let result = ctx
-            .client
-            .session_logs(&self.job_id)
-            .await
-            .context(HttpClientSnafu)?;
+    async fn show_logs(&self, ctx: &Context, seen: usize) -> Result<usize, httpclient::Error> {
+        let result = ctx.client.session_logs(&self.job_id).await?;
         if let Some(lines_blob) = result.0.get("amalthea-session") {
             let lines: Vec<&str> = lines_blob.lines().collect();
             if lines.len() > seen {
@@ -63,12 +59,8 @@ impl Input {
         Ok(seen)
     }
 
-    async fn is_session_finished(&self, ctx: &Context) -> Result<bool, Error> {
-        let details = ctx
-            .client
-            .get_session(&self.job_id)
-            .await
-            .context(HttpClientSnafu)?;
+    async fn is_session_finished(&self, ctx: &Context) -> Result<bool, httpclient::Error> {
+        let details = ctx.client.get_session(&self.job_id).await?;
 
         match &details {
             None => Ok(true),
@@ -76,7 +68,7 @@ impl Input {
         }
     }
 
-    async fn follow_logs(&self, ctx: Context) -> Result<(), Error> {
+    pub async fn follow_logs(&self, ctx: Context) -> Result<(), httpclient::Error> {
         let mut seen: usize = self.show_logs(&ctx, 0).await?;
         if self.is_session_finished(&ctx).await? {
             return Ok(());

--- a/src/cli/cmd/job/start.rs
+++ b/src/cli/cmd/job/start.rs
@@ -1,6 +1,6 @@
 use crate::{
-    cli::complete::complete_job_launcher_id,
-    data::submission_id::SubmissionId,
+    cli::{cmd::job::logs, complete::complete_job_launcher_id},
+    data::{simple_message::SimpleMessage, submission_id::SubmissionId},
     httpclient::{self, data::SessionStartRequest},
 };
 
@@ -32,6 +32,10 @@ pub struct Input {
     /// Overwrite the command that is set in the launcher.
     #[arg(long)]
     pub command: Vec<String>,
+
+    /// Start the job and show the logs until it ends or the user cancels with Ctrl-C.
+    #[arg(long, default_value_t = false)]
+    pub wait: bool,
 
     /// These arguments are passed to the renku job command.
     #[arg(trailing_var_arg = true, allow_hyphen_values = true, num_args = 0.., value_name = "ARGS")]
@@ -76,6 +80,24 @@ impl Input {
             .await
             .context(HttpClientSnafu)?;
 
-        ctx.write_result(&result).await.context(WriteResultSnafu)
+        if self.wait {
+            ctx.write_result(&SimpleMessage {
+                message: format!(
+                    "Started job {} (submission_id: {}). Waiting for logs...",
+                    result.name,
+                    result.submission_id.unwrap_or("-".to_string())
+                ),
+            })
+            .await
+            .context(WriteResultSnafu)?;
+            let log_input = logs::Input {
+                job_id: result.name,
+                follow: true,
+                follow_interval: 2,
+            };
+            log_input.follow_logs(ctx).await.context(HttpClientSnafu)
+        } else {
+            ctx.write_result(&result).await.context(WriteResultSnafu)
+        }
     }
 }


### PR DESCRIPTION
When used, the job is started and logs are printed in the foreground until the job is done.